### PR TITLE
Add initial Iceoryx2Transport with CustomHeader and TransmissionData

### DIFF
--- a/src/custom_header.rs
+++ b/src/custom_header.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2::prelude::*;
+use up_rust::{UMessage, UStatus, UCode};
+
+#[derive(Default, Debug, ZeroCopySend)]
+// optional type name; if not set, `core::any::type_name::<CustomHeader>()` is used
+#[type_name("CustomHeader")]
+#[repr(C)]
+pub struct CustomHeader {
+    pub version: i32,
+    pub timestamp: u64,
+}
+
+impl CustomHeader {
+    pub fn from_user_header(header: &Self) -> Result<Self, UStatus> {
+        Ok(Self {
+            version: header.version,
+            timestamp: header.timestamp,
+        })
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,42 @@
 use async_trait::async_trait;
 use std::sync::Arc;
-use up_rust::{UListener, UMessage, UStatus, UTransport, UUri};
+use up_rust::{UListener, UMessage, UStatus, UTransport, UUri, UCode};
+use iceoryx2::prelude::*;
+use std::sync::Mutex;
+
+
+mod custom_header;
+mod transmission_data;
+pub use custom_header::CustomHeader;
+pub use transmission_data::TransmissionData;
 
 /// This will be the main struct for our uProtocol transport.
 /// It will hold the state necessary to communicate with iceoryx2,
 /// such as the service connection and active listeners.
-pub struct Iceoryx2Transport {}
+pub struct Iceoryx2Transport {
+    node: Node<ipc::Service>,
+}
+
+impl Iceoryx2Transport {
+    pub fn new() -> Result<Self, UStatus> {
+        let node = NodeBuilder::new().create::<ipc::Service>()
+            .map_err(|e| UStatus::fail_with_code(UCode::INTERNAL, &format!("Node error: {e}")))?;
+
+        let service = node
+            .service_builder(&"My/Funk/ServiceName".try_into().unwrap())
+            .publish_subscribe::<TransmissionData>()
+            .user_header::<CustomHeader>()
+            .open_or_create()
+            .map_err(|e| UStatus::fail_with_code(UCode::INTERNAL, &format!("Service error: {e}")))?;
+
+        let publisher = service.publisher_builder().create()
+            .map_err(|e| UStatus::fail_with_code(UCode::INTERNAL, &format!("Publisher error: {e}")))?;
+
+        Ok(Self {
+            node,
+        })
+    }
+}
 
 // The #[async_trait] attribute enables async functions in our trait impl.
 #[async_trait]

--- a/src/transmission_data.rs
+++ b/src/transmission_data.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2::prelude::*;
+use up_rust::{UMessage, UStatus, UCode};
+
+#[derive(Debug, Clone, Copy, ZeroCopySend, Default)]
+// optional type name; if not set, `core::any::type_name::<TransmissionData>()` is used
+#[type_name("TransmissionData")]
+#[repr(C)]
+pub struct TransmissionData {
+    pub x: i32,
+    pub y: i32,
+    pub funky: f64,
+}
+
+impl TransmissionData {
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, UStatus> {
+        if bytes.len() != std::mem::size_of::<Self>() {
+            return Err(UStatus::fail_with_code(
+                UCode::INVALID_ARGUMENT,
+                "Invalid byte length for TransmissionData",
+            ));
+        }
+
+        let mut data = Self {
+            x: 0,
+            y: 0,
+            funky: 0.0,
+        };
+        let ptr = &mut data as *mut Self as *mut u8;
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), ptr, bytes.len());
+        }
+        Ok(data)
+    }
+
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = vec![0u8; std::mem::size_of::<Self>()];
+        let ptr = self as *const Self as *const u8;
+        unsafe {
+            std::ptr::copy_nonoverlapping(ptr, bytes.as_mut_ptr(), bytes.len());
+        }
+        bytes
+    }
+}


### PR DESCRIPTION
- Introduced Iceoryx2Transport with support for publish-subscribe messaging using iceoryx2 (only returns Node for now)
- Set up a service and publisher in Iceoryx2Transport::new()
- Defined TransmissionData as a sample payload (#[repr(C)], ZeroCopySend-compatible)
- Added CustomHeader struct for uProtocol-style user headers
- Prepared groundwork for implementing send() 

